### PR TITLE
Support Route Parameters

### DIFF
--- a/Macros/Tests/HTTPHandlerMacroTests.swift
+++ b/Macros/Tests/HTTPHandlerMacroTests.swift
@@ -47,6 +47,9 @@ struct HTTPHandlerMacroTests {
             try await handler.handleRequest(.make(path: "/accepted")).statusCode == .accepted
         )
         #expect(
+            try await handler.handleRequest(.make(path: "/account/fish")).bodyText == "fish"
+        )
+        #expect(
             try await handler.handleRequest(.make(path: "/teapot")).statusCode == .teapot
         )
         #expect(
@@ -78,6 +81,12 @@ private struct MacroHandler {
     @HTTPRoute("/accepted")
     func willAppear(_ val: HTTPRequest) async -> HTTPResponse {
         HTTPResponse(statusCode: .accepted)
+    }
+
+    @HTTPRoute("/account/:id")
+    func accountID(_ req: HTTPRequest) async -> HTTPResponse {
+        let id = req.routeParameters["id"] ?? ""
+        return HTTPResponse(statusCode: .ok, body: id.data(using: .utf8)!)
     }
 
     @HTTPRoute("/teapot", statusCode: .teapot)

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/swhitty/FlyingFox.git", from: "0.22.0"),
+        .package(url: "https://github.com/swhitty/FlyingFox.git", branch: "main"),
         .package(url: "https://github.com/swiftlang/swift-syntax", "510.0.0"..<"602.0.0")
     ],
     targets: [

--- a/Plugins/Sources/HTTPHandlerMacro.swift
+++ b/Plugins/Sources/HTTPHandlerMacro.swift
@@ -43,7 +43,7 @@ public enum HTTPHandlerMacro: MemberMacro {
     ) throws -> [DeclSyntax] {
         let memberList = declaration.memberBlock.members
 
-        let routes = memberList.compactMap { member -> RouteDecl? in
+        var routes = memberList.compactMap { member -> RouteDecl? in
             guard let funcDecl = FunctionDecl.make(from: member),
                   let routeAtt = funcDecl.attribute(name: "HTTPRoute") ?? funcDecl.attribute(name: "JSONRoute") else {
                 return nil
@@ -65,6 +65,10 @@ public enum HTTPHandlerMacro: MemberMacro {
 
         if routes.isEmpty {
             context.diagnoseWarning(for: node, "No HTTPRoute found")
+        }
+
+        for i in routes.indices {
+            routes[i].idx = i
         }
 
         let routeDecl: DeclSyntax = """
@@ -103,6 +107,7 @@ private extension HTTPHandlerMacro {
         var isJSON: Bool
         var encoder: String
         var decoder: String
+        var idx: Int = 0
 
         var routeSyntax: String {
             if isJSON {
@@ -112,16 +117,29 @@ private extension HTTPHandlerMacro {
             }
         }
 
+        var responseVar: String {
+            "response\(idx)"
+        }
+
         var httpRouteSyntax: String {
             if funcDecl.returnType.isVoid {
                 """
-                if await HTTPRoute("\(route)") ~= request { \(funcCallSyntax)
-                return HTTPResponse(statusCode: \(statusCode), headers: \(headers))
+                let \(responseVar) = try await RoutedHTTPHandler.handleMatchedRequest(request, to: HTTPRoute("\(route)")) { _ in
+                    \(funcCallSyntax)
+                    return HTTPResponse(statusCode: \(statusCode), headers: \(headers))
+                }
+                if let \(responseVar) {
+                    return \(responseVar)
                 }
                 """
             } else {
                 """
-                if await HTTPRoute("\(route)") ~= request { return \(funcCallSyntax) }
+                let \(responseVar) = try await RoutedHTTPHandler.handleMatchedRequest(request, to: HTTPRoute("\(route)")) { _ in
+                    return \(funcCallSyntax)
+                }
+                if let \(responseVar) {
+                    return \(responseVar)
+                }
                 """
             }
         }


### PR DESCRIPTION
Supports route parameters in `@HTTPRoute` handlers.

```swift
@HTTPRoute("/account/:id")
func accountID(_ req: HTTPRequest) async -> HTTPResponse {
   let id = req.routeParameters["id"] ?? ""
   return HTTPResponse(statusCode: .ok, body: id.data(using: .utf8)!)
}
```

A recent change to FlyingFox (https://github.com/swhitty/FlyingFox/pull/171) makes route parameters available to other handlers.

Fixes: #3 


#### 🔮 Future Directions
I intend on making route parameters available to `@JSONRoute` in the future, but the plan is to explicitly type the params making this syntax possible;

```swift
@JSONRoute("/account/:id")
func accountID(_ id: Int) async -> Account {
   let account = try await repo.getAccount(id: id)
   return account
}
```

> `:id` name will be linked to the `id: Int`